### PR TITLE
FTX-918

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ VERSION = "2.0.0"
 REQUIREMENTS = [
     "azure-kusto-data==3.*",
     "sqlalchemy==1.4.*",
-    "typing-extensions~=3.10",
 ]
 EXTRAS = {
     "dev": [


### PR DESCRIPTION
This dependency is not needed and is causing problems where an azure package needs a higher version.